### PR TITLE
Update __init__.py - bringing PR over from OG repo

### DIFF
--- a/custom_components/ecowitt/__init__.py
+++ b/custom_components/ecowitt/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
+    async_get as async_get_entity_registry,
 )
 
 from homeassistant.const import (


### PR DESCRIPTION
async_get_registry was deprecated and removed in hass 2023.5.0. This imports async_get instead and requires only this modification to work in 2023.5.0