### PR TITLE
Update __init__.py with conversion of deprecated async_get_registry to async_get - bringing PR over from OG repo

### DIFF
--- a/custom_components/ecowitt/__init__.py
+++ b/custom_components/ecowitt/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
+    async_get as async_get_entity_registry,
 )
 
 from homeassistant.const import (

--- a/custom_components/ecowitt/__init__.py
+++ b/custom_components/ecowitt/__init__.py
@@ -418,7 +418,7 @@ class EcowittEntity(Entity):
 
         if self._key in discovery_info.keys():
 
-            registry = await async_get_entity_registry(self.hass)
+            registry = async_get_entity_registry(self.hass)
 
             entity_id = registry.async_get_entity_id(
                 discovery_info[self._key], DOMAIN, self.unique_id


### PR DESCRIPTION
async_get_registry is deprecated and was removed in 2023.5.0. Converted use of the deprecated function to the replacement async_get

@nguilbault
[Update __init__.py](https://github.com/garbled1/homeassistant_ecowitt/pull/153/commits/580daadfa84e4206e2f1207d028e504c5a143b0f)
580daad
@bdraco
bdraco commented on May 4, 2023
You also need to remove the await on this line

https://github.com/nguilbault/homeassistant_ecowitt/blob/[580daad](https://github.com/garbled1/homeassistant_ecowitt/pull/153/commits/580daadfa84e4206e2f1207d028e504c5a143b0f)fa84e4206e2f1207d028e504c5a143b0f/custom_components/ecowitt/__init__.py#L421

@nguilbault
[Update __init__.py](https://github.com/garbled1/homeassistant_ecowitt/pull/153/commits/46bf366717d8b9aa6a2816d1e0fe8472300f58fa)
46bf366
@nguilbault
Author
[nguilbault](https://github.com/nguilbault) commented [on May 5, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1536441416)
good catch - that's what I get for assuming that a function named async_get is actually async.

@[mattdevo1](https://github.com/mattdevo1)
mattdevo1 commented [on May 7, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1537730042) • 
Thank you! Fixed my problem after upgrading to 2023.5. Although it looks like this project is dead at this point and there is an official Ecowitt integration now, so I guess I'll be migrating soon.

@[rpajik](https://github.com/rpajik)
rpajik commented [on May 9, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1540237901)
@nguilbault Help a lot, thx. @mattdevo1 official Ecowitt integration is cloud based :-(

@[seidler2547](https://github.com/seidler2547) seidler2547 mentioned this pull request [on May 9, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#ref-issue-1698789400)
https://github.com/garbled1/homeassistant_ecowitt/issues/155
Open
@[mattdevo1](https://github.com/mattdevo1)
mattdevo1 commented [on May 9, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1540582874)
@nguilbault Help a lot, thx. @mattdevo1 official Ecowitt integration is cloud based :-(

The official integration is Local Push (not cloud based) - https://www.home-assistant.io/integrations/ecowitt/

Your Ecowitt hub pushes data to Home Assistant locally. There is no cloud involved.

@[rpajik](https://github.com/rpajik)
rpajik commented [on May 9, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1540678925)
@nguilbault Help a lot, thx. @mattdevo1 official Ecowitt integration is cloud based :-(

The official integration is Local Push (not cloud based) - https://www.home-assistant.io/integrations/ecowitt/

Your Ecowitt hub pushes data to Home Assistant locally. There is no cloud involved.

Sorry, my fault. thx

@[cheechm13](https://github.com/cheechm13) cheechm13 mentioned this pull request [on May 25, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#ref-issue-1726553312)
https://github.com/elad-bar/ha-blueiris/issues/208
Closed
@[nliaudat](https://github.com/nliaudat)
nliaudat commented [on Jun 14, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1591733270)
This repo is dead. Has anyone a good replacement or working fork ?

@[mattdevo1](https://github.com/mattdevo1)
mattdevo1 commented [on Jun 14, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1592247662)
This repo is dead. Has anyone a good replacement or working fork ?

Have you tried the official integration?

https://www.home-assistant.io/integrations/ecowitt/

I haven't migrated yet. Would be interested to hear if it works for you.

@[DMcGav](https://github.com/DMcGav)
DMcGav commented [on Jun 29, 2023](https://github.com/garbled1/homeassistant_ecowitt/pull/153#issuecomment-1613082213)
good catch - that's what I get for assuming that a function named async_get is actually async.

Thanks guys - great fix!